### PR TITLE
fixes #36 Send/Recv deadline is an absolute time.Time

### DIFF
--- a/core.go
+++ b/core.go
@@ -33,8 +33,8 @@ type socket struct {
 
 	closing bool // true if Socket was closed at API level
 
-	rdeadline  time.Time
-	wdeadline  time.Time
+	rdeadline  time.Duration
+	wdeadline  time.Duration
 	reconntime time.Duration // reconnect time after error or disconnect
 	linger     time.Duration
 
@@ -343,12 +343,12 @@ func (sock *socket) SetOption(name string, value interface{}) error {
 	switch name {
 	case OptionRecvDeadline:
 		sock.Lock()
-		sock.rdeadline = value.(time.Time)
+		sock.rdeadline = value.(time.Duration)
 		sock.Unlock()
 		return nil
 	case OptionSendDeadline:
 		sock.Lock()
-		sock.wdeadline = value.(time.Time)
+		sock.wdeadline = value.(time.Duration)
 		sock.Unlock()
 		return nil
 	}

--- a/examples/pair/pair.go
+++ b/examples/pair/pair.go
@@ -27,13 +27,14 @@
 package main
 
 import (
+	"fmt"
+	"os"
+	"time"
+
 	"github.com/gdamore/mangos"
 	"github.com/gdamore/mangos/protocol/pair"
 	"github.com/gdamore/mangos/transport/ipc"
 	"github.com/gdamore/mangos/transport/tcp"
-	"fmt"
-	"os"
-	"time"
 )
 
 func die(format string, v ...interface{}) {
@@ -58,8 +59,7 @@ func recv_name(sock mangos.Socket, name string) {
 
 func send_recv(sock mangos.Socket, name string) {
 	for {
-		sock.SetOption(mangos.OptionRecvDeadline,
-			time.Now().Add(100*time.Millisecond))
+		sock.SetOption(mangos.OptionRecvDeadline, 100*time.Millisecond)
 		recv_name(sock, name)
 		time.Sleep(time.Second)
 		send_name(sock, name)

--- a/options.go
+++ b/options.go
@@ -27,16 +27,16 @@ const (
 	// The value passed is a bool.
 	OptionRaw = "RAW"
 
-	// OptionRecvDeadline is the absolute time when the next Recv should
-	// timeout.  The value is a time.Time.  Zero value may be passed to
-	// indicate that no timeout should be applied.  By default there is
-	// no timeout is used.
+	// OptionRecvDeadline is the time until the next Recv times out.  The
+	// value is a time.Duration.  Zero value may be passed to indicate that no
+	// timeout should be applied.  A negative value indicates a non-blocking
+	// operation.  By default there is no timeout.
 	OptionRecvDeadline = "RECV-DEADLINE"
 
-	// OptionSendDeadline is the absolute time when the next Send should
-	// timeout.  The value is a time.Time.  Zero value may be passed to
-	// indicate that no timeout should be applied.  By default there is
-	// no timeout.
+	// OptionSendDeadline is the time until the next Send times out.  The
+	// value is a time.Duration.  Zero value may be passed to indicate that no
+	// timeout should be applied.  A negative value indicates a non-blocking
+	// operation.  By default there is no timeout.
 	OptionSendDeadline = "SEND-DEADLINE"
 
 	// OptionRetryTime is used by REQ.  The argument is a time.Duration.

--- a/protocol/surveyor/surveyor.go
+++ b/protocol/surveyor/surveyor.go
@@ -152,7 +152,6 @@ func (*surveyor) ValidPeer(peer uint16) bool {
 
 func (x *surveyor) SendHook(m *mangos.Message) bool {
 
-	var timeout time.Time
 	if x.raw {
 		return true
 	}
@@ -164,13 +163,10 @@ func (x *surveyor) SendHook(m *mangos.Message) bool {
 	m.Header = append(m.Header,
 		byte(v>>24), byte(v>>16), byte(v>>8), byte(v))
 
-	if x.duration > 0 {
-		timeout = time.Now().Add(x.duration)
-	}
 	x.Unlock()
 
 	// We cheat and grab the recv deadline.
-	x.sock.SetOption(mangos.OptionRecvDeadline, timeout)
+	x.sock.SetOption(mangos.OptionRecvDeadline, x.duration)
 	return true
 }
 

--- a/test/common_test.go
+++ b/test/common_test.go
@@ -16,9 +16,6 @@
 package test
 
 import (
-	"github.com/gdamore/mangos"
-	"github.com/gdamore/mangos/transport/all"
-	"github.com/gdamore/mangos/transport/tlstcp"
 	"bytes"
 	"encoding/binary"
 	"fmt"
@@ -28,6 +25,10 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/gdamore/mangos"
+	"github.com/gdamore/mangos/transport/all"
+	"github.com/gdamore/mangos/transport/tlstcp"
 )
 
 // T is a structure that subtests can inherit from.
@@ -127,12 +128,12 @@ func (c *T) SendMsg(m *mangos.Message) error {
 	// We sleep a tiny bit, to avoid cramming too many messages on
 	// busses, etc. all at once.  (The test requires no dropped messages.)
 	time.Sleep(c.SendDelay())
-	c.Sock.SetOption(mangos.OptionSendDeadline, time.Now().Add(time.Second*5))
+	c.Sock.SetOption(mangos.OptionSendDeadline, time.Second*5)
 	return c.Sock.SendMsg(m)
 }
 
 func (c *T) RecvMsg() (*mangos.Message, error) {
-	c.Sock.SetOption(mangos.OptionRecvDeadline, time.Now().Add(time.Second*5))
+	c.Sock.SetOption(mangos.OptionRecvDeadline, time.Second*5)
 	return c.Sock.RecvMsg()
 }
 

--- a/util.go
+++ b/util.go
@@ -21,25 +21,17 @@ import (
 	"time"
 )
 
-// mkTimer creates a timer based upon an absolute time.  If however
-// a zero valued time is passed, then a nil channel is passed
+// mkTimer creates a timer based upon a duration.  If however
+// a zero valued duration is passed, then a nil channel is passed
 // i.e. never selectable.  This allows the output to be readily used
 // with deadlines in network connections, etc.
-func mkTimer(deadline time.Time) <-chan time.Time {
+func mkTimer(deadline time.Duration) <-chan time.Time {
 
-	if deadline.IsZero() {
+	if deadline == 0 {
 		return nil
 	}
 
-	dur := deadline.Sub(time.Now())
-	if dur < 0 {
-		// a closed channel never blocks
-		tm := make(chan time.Time)
-		close(tm)
-		return tm
-	}
-
-	return time.After(dur)
+	return time.After(deadline)
 }
 
 var debug = true


### PR DESCRIPTION
This changes OptionRecvDeadline and OptionSendDeadline to use a
time.Duration instead of an absolute time.Time. Fixes #36.