### PR TITLE
Added options for setting uwq/urq sizes

### DIFF
--- a/options.go
+++ b/options.go
@@ -83,4 +83,14 @@ const (
 	// called because it is provided, but this option is useful in the event
 	// that the port is assigned by the OS (i.e. port "0").
 	OptionLocalAddress = "LOCAL-ADDRESS"
+
+	// OptionWriteQLen is used to set the size, in messages, of the write queue
+	// channel. By default, it's 10. This option cannot be set if Dial or
+	// Listen has been called on the socket.
+	OptionWriteQLen = "WRITEQ-LEN"
+
+	// OptionReadQLen is used to set the size, in messages, of the read queue
+	// channel. By default, it's 10. This option cannot be set if Dial or
+	// Listen has been called on the socket.
+	OptionReadQLen = "READQ-LEN"
 )


### PR DESCRIPTION
This sketches out a way to configure the uwq/urq sizes. I'm not sure if I'm completely happy with this yet. Pretty sure there's still potential for a race condition in the case where one thread dials/listens while another sets `OptionUWQSize`/`OptionURQSize`. Seems like locking the socket mutex around the entirety of `Dial` and `Listen` and where the channels get reconfigured in `SetOption` would solve this, but I need to sleep. :sleeping: 
