### PR TITLE
fixes #75 Decorate rx messages with Port

### DIFF
--- a/message.go
+++ b/message.go
@@ -26,6 +26,7 @@ import (
 type Message struct {
 	Header []byte
 	Body   []byte
+	Port   Port
 	bbuf   []byte
 	hbuf   []byte
 	bsize  int
@@ -62,6 +63,7 @@ func (m *Message) Free() {
 			break
 		}
 	}
+	m.Port = nil
 	select {
 	case ch <- m:
 	default:

--- a/pipe.go
+++ b/pipe.go
@@ -113,6 +113,7 @@ func (p *pipe) RecvMsg() *Message {
 		p.Close()
 		return nil
 	}
+	msg.Port = p
 	return msg
 }
 

--- a/test/common_test.go
+++ b/test/common_test.go
@@ -319,6 +319,18 @@ func (c *T) RecvStart() bool {
 		return false
 	}
 	defer m.Free()
+	if addr := m.Port.Address(); addr != c.addr {
+		c.Errorf("Got unexpected message port address: %s", addr)
+		return false
+	}
+	if c.IsServer() && !m.Port.IsServer() {
+		c.Errorf("Expected message port server")
+		return false
+	}
+	if !c.IsServer() && !m.Port.IsClient() {
+		c.Errorf("Expected message port client")
+		return false
+	}
 
 	if v, ok := ParseStart(m); ok {
 		c.Debugf("Got START from %d", v)


### PR DESCRIPTION
This adds the `Port` to the `Message` as described in https://github.com/gdamore/mangos/issues/75. I wasn't entirely sure of the best place to add in test code for this. Can make any needed changes if we think there is a better way/place to test this.