### PR TITLE
Use Message pool on Send to reduce allocations

### DIFF
--- a/core.go
+++ b/core.go
@@ -229,7 +229,8 @@ func (sock *socket) SendMsg(msg *Message) error {
 }
 
 func (sock *socket) Send(b []byte) error {
-	msg := &Message{Body: b, Header: nil, refcnt: 1}
+	msg := NewMessage(0)
+	msg.Body = b
 	return sock.SendMsg(msg)
 }
 


### PR DESCRIPTION
In a tight loop, `Send` causes a lot of allocations. Using the `Message` pool helps reduce this. Now the only place `Message` is allocated is in `NewMessage`.