### PR TITLE
fixes #129 Want anonymous TCP port binding

### DIFF
--- a/core.go
+++ b/core.go
@@ -608,7 +608,7 @@ func (l *listener) Listen() error {
 }
 
 func (l *listener) Address() string {
-	return l.addr
+	return l.l.Address()
 }
 
 func (l *listener) Close() error {

--- a/test/common_test.go
+++ b/test/common_test.go
@@ -635,10 +635,10 @@ var AddrTestInp = "inproc://MYTEST_INPROC"
 var AddrTestTLS = "tls+tcp://127.0.0.1:63934"
 
 // AddrTestWS is a suitable websocket address for testing.
-var AddrTestWS = "ws://127.0.0.1:63935"
+var AddrTestWS = "ws://127.0.0.1:63935/"
 
 // AddrTestWSS is a suitable secure websocket address for testing.
-var AddrTestWSS = "wss://127.0.0.1:63936"
+var AddrTestWSS = "wss://127.0.0.1:63936/"
 
 // RunTestsTCP runs the TCP tests.
 func RunTestsTCP(t *testing.T, cases []TestCase) {

--- a/transport.go
+++ b/transport.go
@@ -118,6 +118,10 @@ type PipeListener interface {
 	// GetOption gets a local option from the listener.
 	// ErrBadOption can be returned for unrecognized options.
 	GetOption(name string) (value interface{}, err error)
+
+	// Address gets the local address.  The value may not be meaningful
+	// until Listen() has been called.
+	Address() string
 }
 
 // Transport is the interface for transport suppliers to implement.

--- a/transport/inproc/inproc.go
+++ b/transport/inproc/inproc.go
@@ -212,6 +212,10 @@ func (l *listener) Listen() error {
 	return nil
 }
 
+func (l *listener) Address() string {
+	return l.addr
+}
+
 func (l *listener) Accept() (mangos.Pipe, error) {
 	server := &inproc{proto: l.proto, addr: addr(l.addr)}
 	server.readyq = make(chan struct{})

--- a/transport/ipc/ipc.go
+++ b/transport/ipc/ipc.go
@@ -84,6 +84,10 @@ func (l *listener) Listen() error {
 	return nil
 }
 
+func (l *listener) Address() string {
+	return "ipc://" + l.addr.String()
+}
+
 // Accept implements the the PipeListener Accept method.
 func (l *listener) Accept() (mangos.Pipe, error) {
 

--- a/transport/tcp/tcp.go
+++ b/transport/tcp/tcp.go
@@ -100,6 +100,7 @@ func (d *dialer) GetOption(n string) (interface{}, error) {
 
 type listener struct {
 	addr     *net.TCPAddr
+	bound    net.Addr
 	proto    mangos.Protocol
 	listener *net.TCPListener
 	opts     options
@@ -123,7 +124,17 @@ func (l *listener) Accept() (mangos.Pipe, error) {
 
 func (l *listener) Listen() (err error) {
 	l.listener, err = net.ListenTCP("tcp", l.addr)
+	if err == nil {
+		l.bound = l.listener.Addr()
+	}
 	return
+}
+
+func (l *listener) Address() string {
+	if b := l.bound; b != nil {
+		return "tcp://" + b.String()
+	}
+	return "tcp://" + l.addr.String()
 }
 
 func (l *listener) Close() error {

--- a/transport/tlstcp/tlstcp.go
+++ b/transport/tlstcp/tlstcp.go
@@ -134,6 +134,10 @@ func (l *listener) Listen() error {
 	return nil
 }
 
+func (l *listener) Address() string {
+	return "tls+tcp://" + l.addr.String()
+}
+
 func (l *listener) Accept() (mangos.Pipe, error) {
 
 	conn, err := l.listener.AcceptTCP()

--- a/transport/ws/ws.go
+++ b/transport/ws/ws.go
@@ -431,6 +431,10 @@ func (l *listener) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	l.wssvr.ServeHTTP(w, r)
 }
 
+func (l *listener) Address() string {
+	return l.url_.String()
+}
+
 func (wsTran) Scheme() string {
 	return "ws"
 }


### PR DESCRIPTION
This gives the dynamically calculated Address() determined post Listen() time.  This works nicely for the TCP and TLS+TCP transports.  Note that as a part of this, for the ws and wss interfaces, we needed to change the tested addresses to cover the canonical form (which includes the trailing slash).

This integration includes a test case that validates proper functionality for this with TCP.